### PR TITLE
Prevent PHP from loading xdebug extension for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,12 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
 apk --no-cache --update add mysql-client php7 php7-common php7-openssl php7-memcached php7-curl php7-zlib php7-xml php7-xmlrpc php7-pdo php7-pdo_mysql php7-pdo_pgsql php7-pdo_sqlite php7-mysqlnd php7-mysqli php7-mcrypt php7-opcache php7-json php7-fpm php7-pear php7-mbstring php7-soap php7-ctype php7-gd php7-dom php7-phar php7-pear php7-ast php7-xdebug && \
     ln -s /usr/bin/php7 /usr/bin/php && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    echo -e ";$(cat /etc/php7/conf.d/xdebug.ini)" > /etc/php7/conf.d/xdebug.ini
+
+# This doesn't help with composer, see https://getcomposer.org/xdebug, so we are doing the above
+# ADD etc/php7/conf.d/WK_xdebug.ini /etc/php7/conf.d/WK_xdebug.ini
+
 
 #
 # Some common nodejs tools

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It was written with the following goals:
 
 Containers
 
-1. PHP CLI
+1. PHP CLI (without xdebug)
 2. PHP Composer
 3. NodeJS (& npm)
 4. GruntJS (global)
@@ -42,7 +42,7 @@ Does not contain:
 1. drush: should be a part of composer in your D8 app
 2. drupal-console : should be a part of composer in your D8 app
 
-## Usage:
+## Usage
 
 run this container, either as a shell or by specifying a command with flags, attach it to whatever volumes and containers you need, and get isolated command environments as you wish.
 
@@ -55,6 +55,13 @@ Consider binding:
 
 * attach anything not disposable, as the container is meant to disappear when it is finished running.
 
+## Notes
+
+- You can get available php variables by running:
+    docker run -ti --rm quay.io/wunder/wundertools-image-fuzzy-developershell
+    php -r "phpinfo();"
+
 ## TODO
 
-1. add more toys
+1. Add more toys
+2. Maybe fork another image that includes xdebug

--- a/etc/php7/conf.d/WK_xdebug.ini
+++ b/etc/php7/conf.d/WK_xdebug.ini
@@ -1,0 +1,4 @@
+[xdebug]
+xdebug.profiler_enable=0
+xdebug.remote_enable=0
+xdebug.remote_autostart=0

--- a/etc/php7/conf.d/xdebug.ini
+++ b/etc/php7/conf.d/xdebug.ini
@@ -1,3 +1,0 @@
-[xdebug]
-xdebug.remote_enable=1
-xdebug.remote_autostart=1


### PR DESCRIPTION
Not enough to disable xdebug functionality with .ini file, see see https://getcomposer.org/xdebug. This will fix #4.
