### PR TITLE
Change dockerfile CMD to use ssh-agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ RUN chown -R app:app /app
 
 USER app
 WORKDIR /app
-CMD ["/bin/zsh"]
+CMD ["/usr/bin/ssh-agent","/bin/zsh"]


### PR DESCRIPTION
This patch changes the image default CMD to use ssh-agent wrapping the zsh command.  This means that entering an ssh passphrase would only need to be done once per session, reducing the number of times shell users would have to enter it.

Some operations such as drush sql-sync require this key some three or four times per operation.

This handles https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues/18
