### PR TITLE
changed dockerfile cmd to entrypoint to fix shell run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ RUN chown -R app:app /app
 
 USER app
 WORKDIR /app
-CMD ["/usr/bin/ssh-agent","/bin/zsh"]
+ENTRYPOINT ["/usr/bin/ssh-agent","/bin/zsh"]


### PR DESCRIPTION
A quick patch to fix the broken command shell.  This patch converts the CMD to an ENTRYPOINT, so that the inherited entrypoint from the alpine-php image is not used.

This fixes https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues/29
