### PR TITLE
added platformsh cli via curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,13 @@ export PATH=$HOME/.composer/vendor/bin:$PATH && \
 drupal init --override
 ADD app/.console/phpcheck.yml /app/.console/phpcheck.yml
 
+### PlatformSH CLI 
+# @TODO this should be build using compsoer. composer builds currently fail, so we simulate it
+#        RUN composer global require platformsh/cli
+#
+RUN curl -L -o /app/.composer/vendor/bin/platform https://github.com/platformsh/platformsh-cli/releases/download/v3.1.1/platform.phar && \
+    chmod a+x /app/.composer/vendor/bin/platform
+
 ### oh-my-zsh
 RUN git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 ADD app/.zshrc /app/.zshrc


### PR DESCRIPTION
Implements a solution for : https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues/28

This patch uses curl to download the platformsh cli phar, and puts it into the global composer vendor/bin path, as though composer had built it.  This is a temporary fix attempt to see if we can get pl.sh cli to work in the image, and has been marked with a @TODO for upgrade.
