### PR TITLE
Make drush and drupal commands consistent. Cleanup .zshrc from legacy configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,13 @@ RUN composer global require drush/drush:8.x
 ### Drupal Console
 RUN composer global require drupal/console:1.0.0-beta1 && \
 export PATH=$HOME/.composer/vendor/bin:$PATH && \
-drupal init --override
+drupal init --override && \
+mkdir -p ~/.config/fish/completions && \
+ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish
 ADD app/.console/phpcheck.yml /app/.console/phpcheck.yml
 
-### PlatformSH CLI 
-# @TODO this should be build using compsoer. composer builds currently fail, so we simulate it
+### PlatformSH CLI
+# @TODO this should be build using composer. Composer builds currently fail, so we simulate it
 #        RUN composer global require platformsh/cli
 #
 RUN curl -L -o /app/.composer/vendor/bin/platform https://github.com/platformsh/platformsh-cli/releases/download/v3.1.1/platform.phar && \

--- a/app/.zshrc
+++ b/app/.zshrc
@@ -79,17 +79,15 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
-# Drupal specific aliases.
-alias app_drupal="/app/project/vendor/bin/drupal --root=/app/project/web "
-alias app_drush="/app/project/vendor/bin/drush --root=/app/project/web "
 # Allow binaries to be easily added to $HOME/bin.
 export PATH="$PATH:$HOME/bin"
 
-# Include paths for different tools.
-export PATH="$PATH:$HOME/.gem/ruby/2.1.0/bin"
-export PATH="$PATH:$HOME/.composer/vendor/bin"
-export PATH="$PATH:$HOME/project/vendor/bin"
+# Include project specific Composer installed binaries.
+# Include these first so that they are preferred.
+export PATH="$PATH:$HOME/vendor/bin"
 
+# Include global Composer installed binaries.
+export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 # Drupal Console configuration.
 source "$HOME/.console/console.rc" 2>/dev/null

--- a/app/.zshrc
+++ b/app/.zshrc
@@ -52,8 +52,6 @@ plugins=(git)
 
 # User configuration
 
-export PATH="$PATH:$HOME/bin:/usr/local/bin"
-
 source $ZSH/oh-my-zsh.sh
 
 # You may need to manually set your language environment
@@ -84,14 +82,14 @@ source $ZSH/oh-my-zsh.sh
 # Drupal specific aliases.
 alias app_drupal="/app/project/vendor/bin/drupal --root=/app/project/web "
 alias app_drush="/app/project/vendor/bin/drush --root=/app/project/web "
+# Allow binaries to be easily added to $HOME/bin.
+export PATH="$PATH:$HOME/bin"
 
 # Include paths for different tools.
 export PATH="$PATH:$HOME/.gem/ruby/2.1.0/bin"
 export PATH="$PATH:$HOME/.composer/vendor/bin"
 export PATH="$PATH:$HOME/project/vendor/bin"
 
-# Stop some grep errors.
-unset GREP_OPTIONS
 
 # Drupal Console configuration.
 source "$HOME/.console/console.rc" 2>/dev/null


### PR DESCRIPTION
Fix for #36. See commits for more info.
