### PR TITLE
Split zshrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN curl -L -o /app/.composer/vendor/bin/platform https://github.com/platformsh/
 ### oh-my-zsh
 RUN git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 ADD app/.zshrc /app/.zshrc
+ADD app/.zshrc.d /app/.zshrc.d
 
 USER root
 

--- a/app/.zshrc
+++ b/app/.zshrc
@@ -2,7 +2,7 @@
 
 # Load from ~/.zshrc.d
 if [ -d "${HOME}/.zshrc.d" ]; then
-        for zshfile in "${HOME}/.zshrc.d/*"; do
+        for zshfile in ${HOME}/.zshrc.d/*; do
                 source "${zshfile}"
         done
         unset zshfile

--- a/app/.zshrc
+++ b/app/.zshrc
@@ -1,93 +1,10 @@
-# Path to your oh-my-zsh installation.
-export ZSH=$HOME/.oh-my-zsh
 
-# Set name of the theme to load.
-# Look in ~/.oh-my-zsh/themes/
-# Optionally, if you set this to "random", it'll load a random theme each
-# time that oh-my-zsh is loaded.
-ZSH_THEME="candy"
 
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
+# Load from ~/.zshrc.d
+if [ -d "${HOME}/.zshrc.d" ]; then
+        for zshfile in "${HOME}/.zshrc.d/*"; do
+                source "${zshfile}"
+        done
+        unset zshfile
+fi
 
-# Uncomment the following line to use hyphen-insensitive completion. Case
-# sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment the following line to disable bi-weekly auto-update checks.
-DISABLE_AUTO_UPDATE="true"
-
-# Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-plugins=(git)
-
-# User configuration
-
-source $ZSH/oh-my-zsh.sh
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# ssh
-# export SSH_KEY_PATH="~/.ssh/dsa_id"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-
-# Allow binaries to be easily added to $HOME/bin.
-export PATH="$PATH:$HOME/bin"
-
-# Include project specific Composer installed binaries.
-# Include these first so that they are preferred.
-export PATH="$PATH:$HOME/vendor/bin"
-
-# Include global Composer installed binaries.
-export PATH="$PATH:$HOME/.composer/vendor/bin"
-
-# Drupal Console configuration.
-source "$HOME/.console/console.rc" 2>/dev/null

--- a/app/.zshrc
+++ b/app/.zshrc
@@ -1,10 +1,11 @@
+####
+# ZSH configuration
+#
 
-
-# Load from ~/.zshrc.d
+# Load any rc files inside ~/.zshrc.d
 if [ -d "${HOME}/.zshrc.d" ]; then
-        for zshfile in ${HOME}/.zshrc.d/*; do
-                source "${zshfile}"
-        done
-        unset zshfile
+  for zshfile in ${HOME}/.zshrc.d/*; do
+    source ${zshfile}
+  done
 fi
 

--- a/app/.zshrc.d/500-default-oh-my-zsh
+++ b/app/.zshrc.d/500-default-oh-my-zsh
@@ -1,0 +1,93 @@
+# Path to your oh-my-zsh installation.
+export ZSH=$HOME/.oh-my-zsh
+
+# Set name of the theme to load.
+# Look in ~/.oh-my-zsh/themes/
+# Optionally, if you set this to "random", it'll load a random theme each
+# time that oh-my-zsh is loaded.
+ZSH_THEME="candy"
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion. Case
+# sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment the following line to disable bi-weekly auto-update checks.
+DISABLE_AUTO_UPDATE="true"
+
+# Uncomment the following line to change how often to auto-update (in days).
+# export UPDATE_ZSH_DAYS=13
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+plugins=(git)
+
+# User configuration
+
+source $ZSH/oh-my-zsh.sh
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# ssh
+# export SSH_KEY_PATH="~/.ssh/dsa_id"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# Allow binaries to be easily added to $HOME/bin.
+export PATH="$PATH:$HOME/bin"
+
+# Include project specific Composer installed binaries.
+# Include these first so that they are preferred.
+export PATH="$PATH:$HOME/vendor/bin"
+
+# Include global Composer installed binaries.
+export PATH="$PATH:$HOME/.composer/vendor/bin"
+
+# Drupal Console configuration.
+source "$HOME/.console/console.rc" 2>/dev/null


### PR DESCRIPTION
Here is an attempt to provide zsh configuration that is split into multiple files, so that pieces can be overridden and extended.

This relates to https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues/36
