### PR TITLE
Prebuild composer cache regarding drupal-composer/drupal-project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ mkdir -p ~/.config/fish/completions && \
 ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish
 ADD app/.console/phpcheck.yml /app/.console/phpcheck.yml
 
+### Drupal 8
+# Prepare composer caches for Drupal 8 project creation.
+RUN composer create-project drupal-composer/drupal-project:8.x-dev /tmp/tmp_drupal8 --stability dev --no-interaction && \
+rm -rf /tmp/tmp_drupal8
+
 ### PlatformSH CLI
 # @TODO this should be build using composer. Composer builds currently fail, so we simulate it
 #        RUN composer global require platformsh/cli


### PR DESCRIPTION
Added installation of drupal-composer/drupal-project to part of the build of this image so that it prebuilds caches for it. This reduces the time of `wundertools init` by 50% and I think there should be no issues with outdated cache files when using this image down the line because composer should check if it's caches are up to date when actually using composer. This should make an impact on #38.
