### PR TITLE
ensure that php-cli is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ADD etc/sudoers.d/app_nopasswd /etc/sudoers.d/app_nopasswd
 RUN apk --no-cache --update add \
 mysql-client \
 postgresql-client \
+php7 \
 php7-ast \
 php7-openssl \
 php7-pear \


### PR DESCRIPTION
This simple patch just ensures that php-cli is installed, as upstream images may revert to installing only php-fpm.