### PR TITLE
Added docker cli to the dev shell image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV DRUSH_VERSION=8.1.9
 ### Common developer tools
 RUN apk --no-cache add \
 curl \
+docker \
 wget \
 git \
 vim \


### PR DESCRIPTION
This patch adds docker cli to the image by adding it to the list of alpine packages added, in early stages of the Dockerfile.