### PR TITLE
Use composer json source instead of composer require statements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ MAINTAINER aleksi.johansson@wunder.io
 
 # Set versions.
 ENV COMPOSER_VERSION=1.3.1
-ENV PRESTISSIMO_VERSION=0.3.5
-ENV DRUPAL_CONSOLE_VERSION=1.0.0-rc14
 ENV PLATFORMSH_CLI_VERSION=3.12.0
-ENV DRUSH_VERSION=8.1.9
 
 ## Global
 
@@ -56,28 +53,19 @@ RUN npm install -g gulp grunt
 ### Composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
 php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} && \
-php -r "unlink('composer-setup.php');" && \
-composer global require "hirak/prestissimo:${PRESTISSIMO_VERSION}"
+php -r "unlink('composer-setup.php');"
 
 ## App user specific
 
 USER app
 
-### Drush
-RUN composer global require drush/drush:${DRUSH_VERSION}
-
-### Drupal Console
-# @TODO this should be built using composer. Composer builds currently fail, so we simulate it
-# RUN composer global require drupal/console:${DRUPAL_CONSOLE_VERSION} --stability dev
-#
-RUN cd /tmp && \
-echo ${DRUPAL_CONSOLE_VERSION} && \
-wget https://github.com/hechoendrupal/DrupalConsole/archive/${DRUPAL_CONSOLE_VERSION}.tar.gz && \
-tar -zxf ${DRUPAL_CONSOLE_VERSION}.tar.gz && \
-mv /tmp/drupal-console-${DRUPAL_CONSOLE_VERSION}/bin/drupal /app/.composer/vendor/bin/ && \
-mv /tmp/drupal-console-${DRUPAL_CONSOLE_VERSION}/bin/drupal.php /app/.composer/vendor/bin/ && \
-cd && \
-rm -rf /tmp/drupal-console-${DRUPAL_CONSOLE_VERSION}
+### Install various composer packages globally, from app/.composer/composer.json
+# This includes:
+#   - drush
+#   - drupal console
+RUN mkdir /app/.composer
+ADD app/.composer/composer.json /app/.composer/composer.json
+RUN composer global update
 
 ### Drupal 8
 # Prepare composer caches for Drupal 8 project creation and init Drupal Console.

--- a/app/.composer/composer.json
+++ b/app/.composer/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "hirak/prestissimo": "0.3.5",
+        "drush/drush": "8.1.9",
+        "dflydev/dot-access-configuration": "dev-master",
+        "psy/psysh": "v0.8.0",
+        "drupal/console-core": "1.0.0-rc14",
+        "drupal/console-en": "1.0.0-rc14",
+        "drupal/console": "1.0.0-rc14"
+    }
+}

--- a/scripts/composer
+++ b/scripts/composer
@@ -9,10 +9,10 @@
 # define which image to use as a command shell image
 #
 # * this image is still under development, and has some quirks.
-# * you will need to occasionally update this image: docker pull quay.io/wunder/wundertools-image-fuzzy-developershell
-# * you can report any image related issues here: https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues
+# * you will need to occasionally update this image: docker pull quay.io/wunder/fuzzy-alpine-devshell
+# * you can report any image related issues here: https://github.com/wunderkraut/image-fuzzy-alpine-devshell/issues
 #
-DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/wundertools-image-fuzzy-developershell"
+DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/fuzzy-alpine-devshell"
 
 # define what paths are used to bind/mount into the container
 PATH_TARGET="$(pwd)"

--- a/scripts/shell
+++ b/scripts/shell
@@ -9,10 +9,10 @@
 # define which image to use as a command shell image
 #
 # * this image is still under development, and has some quirks.
-# * you will need to occasionally update this image: docker pull quay.io/wunder/wundertools-image-fuzzy-developershell
-# * you can report any image related issues here: https://github.com/wunderkraut/wundertools-image-fuzzy-developershell/issues
+# * you will need to occasionally update this image: docker pull quay.io/wunder/fuzzy-alpine-devshell
+# * you can report any image related issues here: https://github.com/wunderkraut/image-fuzzy-alpine-devshell/issues
 #
-DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/wundertools-image-fuzzy-developershell"
+DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/fuzzy-alpine-devshell"
 
 # define what paths are used to bind/mount into the container
 PATH_TARGET="$(pwd)"


### PR DESCRIPTION
This patch moves a number of the Dockerfile `composer global require` statements to a composer.json file.

The downsides:
- we lose version control through environment variables in the build

[this implements https://github.com/wunderkraut/image-fuzzy-alpine-devshell/issues/55]