### PR TITLE
update drush and drupal console version (composer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ mysql-client \
 postgresql-client \
 php7-ast \
 php7-openssl \
-php7-tokenizer \
 php7-pear \
 php7-phar \
 php7-tokenizer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ mysql-client \
 postgresql-client \
 php7-ast \
 php7-openssl \
+php7-tokenizer \
 php7-pear \
 php7-phar \
 php7-tokenizer \

--- a/app/.composer/composer.json
+++ b/app/.composer/composer.json
@@ -1,11 +1,11 @@
 {
     "require": {
         "hirak/prestissimo": "0.3.5",
-        "drush/drush": "8.1.9",
+        "drush/drush": "8.1.12",
         "dflydev/dot-access-configuration": "dev-master",
         "psy/psysh": "v0.8.0",
-        "drupal/console-core": "1.0.0-rc14",
-        "drupal/console-en": "1.0.0-rc14",
-        "drupal/console": "1.0.0-rc14"
+        "drupal/console-core": "1.0.0-rc25",
+        "drupal/console-en": "1.0.0-rc25",
+        "drupal/console": "1.0.0-rc25"
     }
 }


### PR DESCRIPTION
This patch updates the composer included versions for drush and drupal console.  It also includes the php-tokenizer extension which is now a required piece of the composer includes needed.

> nikic/php-parser v3.0.6 requires ext-tokenizer * -> the requested PHP extension tokenizer is missing from your system.

whic occurs when we do the global composer update.