### PR TITLE
Feature/#65 update base to 7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION v7.1.5-0
 #
-FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.1.5-0-pre3
+FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.1.5
 MAINTAINER aleksi.johansson@wunder.io
 
 # Set versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION v7.1.5-0
 #
-FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.1.5-0-pre
+FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.1.5-0-pre3
 MAINTAINER aleksi.johansson@wunder.io
 
 # Set versions.
@@ -12,26 +12,27 @@ ENV PLATFORMSH_CLI_VERSION=3.12.0
 ## Global
 
 ### Common developer tools
-RUN apk --no-cache add \
-curl \
-docker \
-wget \
-git \
-vim \
-zsh \
-tar \
-gzip \
-p7zip \
-py-yaml \
-xz \
-nodejs \
-sudo \
-openssh \
-openssl \
-ansible \
-rsync && \
-rm -rf /tmp/* && \
-rm -rf /var/cache/apk/*
+RUN apk --no-cache --update add \
+      curl \
+      docker \
+      wget \
+      git \
+      vim \
+      zsh \
+      tar \
+      gzip \
+      p7zip \
+      py-yaml \
+      xz \
+      nodejs \
+      sudo \
+      openssh \
+      openssl \
+      ansible \
+      rsync && \
+    # Cleanup
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/*
 ADD etc/sudoers.d/app_nopasswd /etc/sudoers.d/app_nopasswd
 
 ### PHP and MySQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk --no-cache --update add \
       py-yaml \
       xz \
       nodejs \
+      nodejs-npm \
       sudo \
       openssh \
       openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ php7-ast \
 php7-openssl \
 php7-pear \
 php7-phar \
+php7-tokenizer \
 php7-zlib && \
 rm -rf /tmp/* && \
 rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # wunder/fuzzy-alpine-devshell
 #
-# VERSION v7.0.12-3
+# VERSION v7.1.5-0
 #
-FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.0.12
+FROM quay.io/wunder/fuzzy-alpine-php-dev:v7.1.5-0-pre
 MAINTAINER aleksi.johansson@wunder.io
 
 # Set versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ php7-openssl \
 php7-pear \
 php7-phar \
 php7-zlib && \
-ln -s /usr/bin/php7 /usr/bin/php && \
 rm -rf /tmp/* && \
 rm -rf /var/cache/apk/*
 ADD etc/php7/conf.d/WK_date.ini /etc/php7/conf.d/WK_date.ini


### PR DESCRIPTION
Update base image to Alpine 3.6 and PHP 7.1.5.

Also had to do the following changes because of upstream changes:
- Consistent markup for `RUN apk ...`
- Add `nodejs-npm` package which was separated from `nodejs`
- Add `php7-tokenizer` package
- Remove symlink from `php7` executable to `php` executable because `php7` defaults to `php` now in Alpine 3.6.

Fixes #65.