### PR TITLE
71 added php7-simplexml to fix drush make php error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ php7-openssl \
 php7-pear \
 php7-phar \
 php7-tokenizer \
-php7-zlib && \
+php7-zlib \
+php7-simplexml && \
 rm -rf /tmp/* && \
 rm -rf /var/cache/apk/*
 ADD etc/php7/conf.d/WK_date.ini /etc/php7/conf.d/WK_date.ini


### PR DESCRIPTION
This patch fixes a drush-make error, which is caused by a missing php extension.

The patch adds the php7 simplexml extension, as one of the additional php7 packages added for just this image.

This delivers #72 